### PR TITLE
docs: clarify architecture and patch workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,9 +3,9 @@
 Oblique is a minimal, shader‑driven AV synthesizer focused on modularity,
 real‑time performance and audio‑reactive visuals. It currently targets macOS on
 Apple Silicon; GLSL 330 is required. The MVP supports audio input only—no scene
-engine, MIDI or REPL yet. Design is inspired by Ryoji Ikeda, Max Cooper and
-TouchDesigner while remaining code‑only and extensible. Follow a stateless,
-unidirectional data flow similar to React.
+engine, MIDI or REPL yet. Design is inspired by ShaderToy and
+TouchDesigner while remaining code‑only, extensible and reliability+performance focused.
+Follows a stateless, unidirectional data flow fully in code. 
 
 ## Repository Structure
 
@@ -19,7 +19,7 @@ unidirectional data flow similar to React.
 
 ## Architecture
 
-Oblique follows `Input → Processing → AV Module → Output`.
+Data flow follows `Input → Processing → AV Module → Output`.
 Modules extend `BaseAVModule` and expose metadata:
 
 ```python
@@ -30,8 +30,7 @@ metadata = {
 }
 ```
 
-Each module has a Python file and matching `.frag` shader in `/shaders`.
-Parameters should be defined via dataclasses to provide strongly typed values to
+Module parameters should be defined via dataclasses to provide strongly typed values to
 shaders. Prefer adding new modules over modifying the core engine.
 
 ## Python Rules
@@ -40,9 +39,9 @@ shaders. Prefer adding new modules over modifying the core engine.
 2. Follow PEP 8 and keep lines ≤100 characters
 3. Document modules, classes and functions with docstrings
 4. Keep code simple; prefer list comprehensions
-5. Use type hints and dataclasses; avoid globals
+5. Use type hints and dataclasses; avoid globals. Strong typing where-ever possible.
 6. Handle exceptions with `try`/`except`
-7. Use absolute imports and virtual environments
+7. Use absolute imports and virtual environments. When attempting to run, load venv first. 
 8. Write tests and run them
 9. Employ strong typing for module/shader interfaces
 10. Run command‑line tests with `./start.sh` unless parameters need changes
@@ -50,23 +49,16 @@ shaders. Prefer adding new modules over modifying the core engine.
 
 ## Shader Conventions
 
-- One `.frag` shader per module; file name matches module class
-  (`snake_case.py` → `kebab-case.frag`)
 - Shaders start with `#version 330` and a top comment block describing the
   module, author and inputs
 - Fragment shader holds most logic; add a vertex shader only if required
-- Support optional ping‑pong or off‑screen passes
+- Support optional ping‑pong or off‑screen passes. 
 
 ## Performance
 
 - Target 60 FPS at 1080p on Apple Silicon
 - Avoid blocking CPU calls and large CPU↔GPU transfers
 - Render visuals on the GPU
-
-## Roadmap Notes
-
-Scenes, timeline control, MIDI/OSC/REPL support and cross‑platform capability
-will arrive after the MVP.
 
 ## AI Agent Support
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,88 @@
+# Project Agent Guide for Oblique
+
+Oblique is a minimal, shader‑driven AV synthesizer focused on modularity,
+real‑time performance and audio‑reactive visuals. It currently targets macOS on
+Apple Silicon; GLSL 330 is required. The MVP supports audio input only—no scene
+engine, MIDI or REPL yet. Design is inspired by Ryoji Ikeda, Max Cooper and
+TouchDesigner while remaining code‑only and extensible. Follow a stateless,
+unidirectional data flow similar to React.
+
+## Repository Structure
+
+- `/core`: engine, renderer and patch definitions
+- `/inputs`: audio and other data sources
+- `/processing`: signal processing operators
+- `/modules`: AV modules pairing Python with GLSL shaders
+- `/shaders`: fragment shaders and shared GLSL snippets
+- `/projects`: example patches and experiments
+- `/external`: third‑party resources
+
+## Architecture
+
+Oblique follows `Input → Processing → AV Module → Output`.
+Modules extend `BaseAVModule` and expose metadata:
+
+```python
+metadata = {
+    "name": "Example",
+    "description": "What it does",
+    "parameters": {"param": float},
+}
+```
+
+Each module has a Python file and matching `.frag` shader in `/shaders`.
+Parameters should be defined via dataclasses to provide strongly typed values to
+shaders. Prefer adding new modules over modifying the core engine.
+
+## Python Rules
+
+1. Use meaningful names
+2. Follow PEP 8 and keep lines ≤100 characters
+3. Document modules, classes and functions with docstrings
+4. Keep code simple; prefer list comprehensions
+5. Use type hints and dataclasses; avoid globals
+6. Handle exceptions with `try`/`except`
+7. Use absolute imports and virtual environments
+8. Write tests and run them
+9. Employ strong typing for module/shader interfaces
+10. Run command‑line tests with `./start.sh` unless parameters need changes
+11. Use `rg` for searches; avoid `grep -R` or `ls -R`
+
+## Shader Conventions
+
+- One `.frag` shader per module; file name matches module class
+  (`snake_case.py` → `kebab-case.frag`)
+- Shaders start with `#version 330` and a top comment block describing the
+  module, author and inputs
+- Fragment shader holds most logic; add a vertex shader only if required
+- Support optional ping‑pong or off‑screen passes
+
+## Performance
+
+- Target 60 FPS at 1080p on Apple Silicon
+- Avoid blocking CPU calls and large CPU↔GPU transfers
+- Render visuals on the GPU
+
+## Roadmap Notes
+
+Scenes, timeline control, MIDI/OSC/REPL support and cross‑platform capability
+will arrive after the MVP.
+
+## AI Agent Support
+
+- Document every parameter and shader uniform
+- New modules must include metadata and testable update/render functions
+- Prefer declarative, stateless designs with clear type‑safe interfaces
+
+## Testing
+
+Run tests after changes:
+
+```bash
+pytest
+```
+
+## Pull Requests
+
+- Provide a concise summary of changes
+- Report test results in the PR description

--- a/README.md
+++ b/README.md
@@ -1,24 +1,65 @@
-# Oblique - Modular AV Synthesizer
+# Oblique – Modular AV Synthesizer
 
-A minimal, shader-driven AV synthesizer focused on modularity, real-time performance, and audio-reactive visuals.
+Oblique is a Python‑orchestrated, Shadertoy‑style engine for real‑time, audio‑reactive
+visuals.  It targets artists who want to pair live music with live visuals and includes
+bindings for external devices such as Elektron gear.
 
-## Architecture
+## How it Works
 
-Oblique follows a clean architecture: **Input → Processing → Rendering → Output**
+Oblique follows a simple flow: **Input → Processing → AV Modules → Output**
 
-- **Input**: Raw audio, MIDI, OSC, time signals
-- **Processing**: Feature extraction, normalization, event detection
-- **Rendering**: Modular shader units with type-safe uniforms
-- **Output**: Real-time audiovisual composition
+- **Input** – Audio files, live audio, MIDI, OSC, or time signals
+- **Processing** – Feature extraction, normalization and event detection
+- **AV Modules** – Fragment‑shader based visual units
+- **Output** – Real‑time composition rendered to the screen
+
+### AV Modules
+
+Modules loosely follow the Shadertoy rendering model: a stock vertex shader drives a
+full‑screen quad while the fragment shader contains the creative logic.  Modules may
+optionally use ping‑pong buffers for feedback and additional off‑screen passes for
+intermediate compositing.
+
+### Patches
+
+Most of the magic lives in a **patch** – a small Python function that returns an
+`ObliquePatch` describing the inputs and AV module to run.  Here's a tiny patch that
+plays an audio file while rendering a beat‑reactive circle:
+
+```python
+from core.oblique_patch import ObliquePatch
+from inputs.audio_file_input import AudioFileInput
+from modules.audio_reactive.circle_echo import CircleEcho, CircleEchoParams
+from processing.fft_bands import FFTBands
+
+def circle_patch(width, height):
+    audio = AudioFileInput("beat.wav")
+    fft = FFTBands(audio)
+    circle = CircleEcho(CircleEchoParams(width=width, height=height), fft)
+
+    def tick(t: float):
+        return circle
+
+    return ObliquePatch(audio_output=audio, tick_callback=tick)
+```
+
+Save this as `circle_patch.py` and wire it up in your own runner or modify `main.py` to
+load the patch.
 
 ## Key Features
 
-- **Type-Safe Uniforms**: Dataclass-based uniform contracts prevent shader errors
-- **State flows in one direction**: data flows down and defines state, REACT style approach. 
-- **Audio-Reactive**: Real-time audio analysis and feature extraction
-- **Modular Design**: Easy to create new visual modules
-- **GPU-Native**: All visuals rendered via GLSL shaders
-- **Performance**: 60 FPS @ 1080p on Apple Silicon
+- **One‑way state flow**: data flows downward, React‑style
+- **Audio‑reactive** analysis and feature extraction
+- **Modular design** for creating new visual units
+- **Hardware integration** with external devices (e.g. Elektron Syntakt)
+- **GPU‑native** GLSL rendering
+- **Performance**: 60 FPS @ 1080p on Apple Silicon
+
+## Current Limitations
+
+- Optimised for Apple Silicon with Metal‑backed OpenGL
+- Requires GLSL **330 core** shaders
+- No cross‑platform support at the moment
 
 ## Quick Start
 
@@ -33,29 +74,20 @@ Oblique follows a clean architecture: **Input → Processing → Rendering → O
 python main.py --audio "path/to/audio.wav" --width 800 --height 600 --audio "path_to_audio"
 ```
 
-## Folder struture 
-/oblique/
-├── main.py                    # Launches the engine and test modules
-├── core/                      # Engine loop, base module interface
-│   ├── engine.py             # Main AV engine (composition, routing)
-│   ├── base_module.py        # Base class for rendering modules
-│   └── signal_processor.py   # Signal processing and normalization
-├── input/                     # Raw signal collection
-│   ├── audio/                # Audio input and FFT analysis
-│   ├── midi/                 # MIDI input (future)
-│   └── osc/                  # OSC input (future)
-├── processing/                # Signal processing and feature extraction
-│   ├── audio_features.py     # FFT, envelope, peak detection
-│   ├── signal_normalizer.py  # Normalize various input types
-│   └── event_detector.py     # Beat detection, triggers
-├── modules/                   # Visual rendering modules
-│   └── animated_grid.py      # Example module
-├── shaders/                   # GLSL fragment shaders for modules
-├── output/                    # Final composition and delivery
-│   ├── compositor.py         # Module blending and composition
-│   └── display.py            # Window, Syphon, recording
-├── install.sh                 # Dependency installation
-├── start.sh                   # Starts a run with default settings
+## Repository Structure
+
+```
+oblique/
+├── core/          # Engine loop, renderer and patch definitions
+├── inputs/        # Audio and other data sources
+├── modules/       # AV modules paired with GLSL shaders
+├── processing/    # Signal processing operators
+├── shaders/       # Shared GLSL snippets
+├── external/      # Third-party resources
+├── projects/      # Example patches and experiments
+├── main.py        # Entry point loading an ObliquePatch
+├── install.sh     # Dependency installation
+├── start.sh       # Demo runner
 └── README.md
 ```
 

--- a/core/oblique_engine.py
+++ b/core/oblique_engine.py
@@ -1,3 +1,15 @@
+"""Core runtime for Oblique.
+
+This module hosts :class:`ObliqueEngine`, the high level coordinator that ties
+audio inputs, processing operators and shader based AV modules together.  The
+engine drives the classic Oblique flow of **Input → Processing → AV Module →
+Output**, rendering the final composition to screen.
+
+The current implementation targets Apple Silicon and assumes an OpenGL 3.3 /
+GLSL 330 context provided by macOS' Metal backed driver.  Other platforms have
+not been tested.
+"""
+
 import threading
 import time
 from typing import Dict, Optional
@@ -13,9 +25,19 @@ from inputs.base_input import BaseInput
 
 
 class ObliqueEngine:
-    """
-    Main engine for running Oblique patches with audio playback and video rendering.
-    Handles the complete audio-visual pipeline from patch execution to screen output.
+    """Coordinate input capture, processing and shader based rendering.
+
+    The engine consumes an :class:`~core.oblique_patch.ObliquePatch` produced by a
+    user-defined *patch* function.  It pulls data from ``BaseInput``
+    implementations, feeds it through processing operators and hands the results to
+    the active AV module for fragment‑shader rendering.  The design mirrors
+    Shadertoy: a stock vertex shader draws a fullscreen quad while module fragment
+    shaders produce the visuals.  Audio playback is managed in a separate thread.
+
+    Notes
+    -----
+    Currently optimised for Apple Silicon and GLSL 330; other platforms are
+    untested.  See ``projects/demo/demo_audio_file.py`` for an example patch.
     """
 
     def __init__(

--- a/main.py
+++ b/main.py
@@ -1,3 +1,12 @@
+"""Command line entry point for the Oblique AV engine.
+
+This script configures audio inputs, selects demo patches and launches the
+real‑time engine.  Patches are small Python modules that return an
+``ObliquePatch`` tying together inputs and AV modules (see ``projects/demo`` for
+examples).  The script exists primarily for development and assumes Apple
+Silicon with GLSL 330 support.
+"""
+
 import argparse
 
 # --- Core imports ---

--- a/modules/core/base_av_module.py
+++ b/modules/core/base_av_module.py
@@ -1,3 +1,12 @@
+"""Foundations for Oblique's shader‑driven AV modules.
+
+Modules follow a Shadertoy‑like model: a fixed vertex shader draws a fullscreen
+quad while fragment shaders implement the visuals.  The framework provides
+helpers for optional ping‑pong buffering and additional off‑screen passes,
+allowing complex compositions while keeping Python orchestration minimal.  The
+code is optimised for Apple Silicon and GLSL 330.
+"""
+
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any, Callable, Generic, TypedDict, TypeVar, Union, cast, overload
@@ -22,7 +31,11 @@ ParamStrList = Union[list[str], Callable[[], list[str]], BaseProcessingOperator[
 
 # Texture params
 ParamTexture = Union[moderngl.Texture, Callable[[], moderngl.Texture], "BaseAVModule"]
-ParamTextureList = Union[list[moderngl.Texture], Callable[[], list[moderngl.Texture]], list["BaseAVModule"]]
+ParamTextureList = Union[
+    list[moderngl.Texture],
+    Callable[[], list[moderngl.Texture]],
+    list["BaseAVModule"],
+]
 
 # --- Base params dataclass ---
 @dataclass
@@ -34,7 +47,12 @@ class BaseAVParams:
 # --- Unified texture pass dataclass ---
 @dataclass
 class TexturePass:
-    """A renderable texture pass used for both on-screen and off-screen rendering.
+    """A Shadertoy‑style pass for on‑screen or off‑screen rendering.
+
+    Each pass runs a fragment shader and outputs a texture; it never draws to
+    the screen directly.  Optional ping‑pong feedback lets a pass read its
+    previous result, and passes can be chained to form more complex
+    compositions or used as intermediate buffers.
 
     Attributes
     ----------
@@ -43,24 +61,27 @@ class TexturePass:
     frag_shader_path:
         Path to the fragment shader for this pass.
     uniforms:
-        Mapping uniform_name → source where source can be:
-            • A `TexturePass` instance – its rendered texture will be injected.
-            • A `BaseAVModule` instance – its rendered texture will be injected.
-            • A `moderngl.Texture` instance.
+        Mapping ``uniform_name → source`` where source can be:
+            • A ``TexturePass`` instance – its rendered texture will be injected.
+            • A ``BaseAVModule`` instance – its rendered texture will be injected.
+            • A ``moderngl.Texture`` instance.
             • Any primitive value (int, float, bool, str, tuple, list, etc.)
         At runtime each pair produces a uniform named ``u_<uniform_name>`` unless the key
         already starts with ``u_``.
     width / height:
         Optional fixed resolution for this pass. If omitted, the caller's resolution is used.
     ping_pong:
-        Enable double-buffered rendering. When true, the pass alternates cached targets per frame.
+        Enable double‑buffered rendering. When true, the pass alternates cached targets per frame.
     previous_uniform_name:
-        If ping-pong is enabled and a previous texture exists, it will be injected under this
+        If ping‑pong is enabled and a previous texture exists, it will be injected under this
         uniform name (default: ``u_previous``).
     """
 
     frag_shader_path: str
-    uniforms: dict[str, Union["TexturePass", "BaseAVModule", moderngl.Texture, int, float, bool, str, tuple, list]] = field(default_factory=dict)
+    uniforms: dict[
+        str,
+        Union["TexturePass", "BaseAVModule", moderngl.Texture, int, float, bool, str, tuple, list],
+    ] = field(default_factory=dict)
     width: int | None = None
     height: int | None = None
     ping_pong: bool = False
@@ -82,28 +103,32 @@ U = TypeVar("U", bound="Uniforms")
 
 
 class BaseAVModule(ObliqueNode, ABC, Generic[P, U]):
-    """
-    Base class for all AV modules. Defines the required interface for AV modules.
+    """Abstract base for all shader‑driven AV modules.
 
-    Required attributes and methods:
-    - metadata: dict[str, Any] with keys 'name', 'description', 'parameters'
-    - frag_shader_path: str (must be set by subclass)
-    - __init__(params: BaseAVParams): Initialize the module with parameters (subclass of BaseAVParams)
-    - prepare_uniforms(t: float) -> RenderData:
-        Prepare uniform data and shader information for rendering. Return a RenderData dict with:
-            'frag_shader_path': str (path to the fragment shader)
-            'uniforms': Uniforms (uniforms to pass to the shader)
-        This data will be used by the renderer to draw the module.
+    Subclasses provide a GLSL fragment shader and implement :meth:`prepare_uniforms`
+    to supply typed uniforms.  At render time the framework pairs that fragment
+    shader with the stock fullscreen vertex shader, optionally managing
+    ping‑pong or additional off‑screen passes defined via :class:`TexturePass`.
 
-    Optional methods:
-    - render_texture(ctx: moderngl.Context, width: int, height: int, t: float) -> moderngl.Texture:
-        Override this method to provide custom texture rendering behavior.
-        Default implementation uses prepare_uniforms() method and render_to_texture().
+    Required attributes and methods
+    --------------------------------
+    - ``metadata`` – ``dict`` with keys ``name``, ``description``, ``parameters``
+    - ``frag_shader_path`` – path to the fragment shader
+    - ``__init__(params: BaseAVParams)`` – initialise with module‑specific parameters
+    - ``prepare_uniforms(t: float) -> RenderData`` – return fragment shader path and uniforms
+
+    Optional methods
+    ----------------
+    - ``render_texture(ctx, width, height, t)`` – override to customise rendering
+      beyond the default :func:`core.renderer.render_to_texture`
     """
 
     metadata: dict[str, Any] = {
         "name": "BaseAVModule",
-        "description": "Abstract base class for AV modules. Subclasses must define metadata, update, and render methods.",
+        "description": (
+            "Abstract base class for AV modules. "
+            "Subclasses must define metadata, update, and render methods."
+        ),
         "parameters": {},
     }
     frag_shader_path: str  # Must be set by subclass


### PR DESCRIPTION
## Summary
- highlight patch-driven workflow with beat-reactive example
- document ObliqueEngine patch usage and correct TexturePass description
- expand repository agent guide with structure, conventions and testing
- document repository structure in README
- add detailed project overview, architecture guidelines and coding rules to AGENTS.md

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'core')*


------
https://chatgpt.com/codex/tasks/task_e_689e369401f883288fe13b6decb9304f