### PR TITLE
Add comprehensive processing tests for high coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,6 @@
+[run]
+source = processing
+
+[report]
+exclude_lines =
+    pragma: no cover

--- a/processing/envelope.py
+++ b/processing/envelope.py
@@ -29,7 +29,7 @@ class Envelope(BaseProcessingOperator[float]):
         return self.value
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     import numpy as np
 
     # Example: follow a noisy sine wave

--- a/processing/fft_bands.py
+++ b/processing/fft_bands.py
@@ -137,7 +137,7 @@ class FFTBands(BaseProcessingOperator[List[float]]):
         for b in self.band_bins:
             if b.size > 0:
                 band_mag = mag[b].mean()
-            else:
+            else:  # pragma: no cover - band bins precomputed to be non-empty
                 band_mag = 0.0
             bands.append(band_mag)
 

--- a/processing/normalized_amplitude.py
+++ b/processing/normalized_amplitude.py
@@ -72,7 +72,7 @@ class NormalizedAmplitudeOperator(BaseProcessingOperator[float]):
         return float(normalized)
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     import sys
 
     from inputs.audio.core.audio_file_input import AudioFileInput

--- a/processing/spectral_centroid.py
+++ b/processing/spectral_centroid.py
@@ -74,7 +74,7 @@ class SpectralCentroid(BaseProcessingOperator[float]):
         return float(humanized)
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     import sys
 
     from inputs.audio.core.audio_file_input import AudioFileInput

--- a/processing/spectral_flux.py
+++ b/processing/spectral_flux.py
@@ -40,7 +40,7 @@ class SpectralFlux(BaseProcessingOperator[float]):
         return float(flux)
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     import sys
 
     from inputs.audio.core.audio_device_input import AudioDeviceInput

--- a/processing/zero_crossing_rate.py
+++ b/processing/zero_crossing_rate.py
@@ -35,7 +35,7 @@ class ZeroCrossingRate(BaseProcessingOperator[float]):
         return float(rate)
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     import sys
 
     from inputs.audio.core.audio_device_input import AudioDeviceInput

--- a/tests/processing/test_envelope.py
+++ b/tests/processing/test_envelope.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+import numpy as np
+
+from tests.utils.stubs import setup_stubs, load_module
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_envelope_smoothing() -> None:
+    setup_stubs()
+    mod = load_module("processing.envelope", ROOT / "processing" / "envelope.py")
+
+    values = [1.0, 0.0]
+
+    def input_fn() -> float:
+        return values.pop(0) if values else 0.0
+
+    env = mod.Envelope(input_fn, decay=0.5)
+    assert np.isclose(env.process(), 0.5)
+    assert np.isclose(env.process(), 0.25)

--- a/tests/processing/test_fft_bands.py
+++ b/tests/processing/test_fft_bands.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+
+import numpy as np
+
+from tests.utils.stubs import setup_stubs, load_module
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class DummyAudio:
+    def __init__(self, chunks, sample_rate: int = 48000) -> None:
+        self.chunks = list(chunks)
+        self.sample_rate = sample_rate
+
+    def peek(self, n_buffers: int = 1, channels=None):  # pragma: no cover - interface placeholder
+        return self.chunks.pop(0) if self.chunks else None
+
+
+def test_fft_bands_basic() -> None:
+    setup_stubs()
+    mod = load_module("processing.fft_bands", ROOT / "processing" / "fft_bands.py")
+
+    chunks = [
+        np.array([], dtype=np.float32),
+        np.ones((4, 2), dtype=np.float32),
+        np.ones(10, dtype=np.float32),
+        np.ones(8, dtype=np.float32) * 2,
+    ]
+    audio = DummyAudio(chunks)
+    fft = mod.FFTBands(audio, n_fft=8, num_bands=4, smoothing_factor=0.5)
+
+    assert fft.process() == [0.0] * 4  # empty chunk
+    assert fft.process() == [0.0] * 4  # still filling buffer
+    res = fft.process()
+    assert len(res) == 4 and all(0.0 <= v <= 1.0 for v in res)
+    res2 = fft.process()
+    assert len(res2) == 4 and all(0.0 <= v <= 1.0 for v in res2)
+
+
+def test_fft_bands_missing_audio() -> None:
+    setup_stubs()
+    mod = load_module("processing.fft_bands", ROOT / "processing" / "fft_bands.py")
+
+    audio = DummyAudio([None])
+    fft = mod.FFTBands(audio, n_fft=8, num_bands=2)
+    assert fft.process() == [0.0, 0.0]

--- a/tests/processing/test_normalized_amplitude.py
+++ b/tests/processing/test_normalized_amplitude.py
@@ -41,3 +41,17 @@ def test_normalized_amplitude_curves() -> None:
     with pytest.raises(ValueError):
         op.process()
 
+
+def test_normalized_amplitude_edge_cases() -> None:
+    setup_stubs()
+    mod = load_module("processing.normalized_amplitude", ROOT / "processing" / "normalized_amplitude.py")
+
+    op = mod.NormalizedAmplitudeOperator(DummyInput(np.array([])))
+    assert op.process() == 0.0
+
+    op = mod.NormalizedAmplitudeOperator(DummyInput(np.zeros(4)))
+    assert op.process() == 0.0
+
+    op = mod.NormalizedAmplitudeOperator(DummyInput(np.array([0.1, 0.1])))
+    assert op.process() > 0.0
+

--- a/tests/processing/test_spectral_flux.py
+++ b/tests/processing/test_spectral_flux.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+import sys
+import types
+
+import numpy as np
+
+from tests.utils.stubs import setup_stubs, load_module
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def load_spectral_flux():
+    setup_stubs()
+    module = types.ModuleType("inputs.audio.core.audio_device_input")
+    class AudioDeviceInput:  # pragma: no cover - placeholder for import
+        pass
+    module.AudioDeviceInput = AudioDeviceInput
+    sys.modules["inputs.audio.core.audio_device_input"] = module
+    return load_module("processing.spectral_flux", ROOT / "processing" / "spectral_flux.py")
+
+
+class DummyAudio:
+    def __init__(self, chunks):
+        self.chunks = list(chunks)
+
+    def peek(self):  # pragma: no cover - interface placeholder
+        return self.chunks.pop(0) if self.chunks else None
+
+
+def test_spectral_flux_basic() -> None:
+    mod = load_spectral_flux()
+    audio = DummyAudio([np.ones(8), np.zeros(8)])
+    op = mod.SpectralFlux(audio)
+    assert op.process() == 0.0
+    assert op.process() > 0.0
+
+
+def test_spectral_flux_edge_cases() -> None:
+    mod = load_spectral_flux()
+    assert mod.SpectralFlux(DummyAudio([None])).process() == 0.0
+    assert mod.SpectralFlux(DummyAudio([np.array([])])).process() == 0.0
+
+    audio = DummyAudio([np.ones((8, 2)), np.zeros((8, 2))])
+    op = mod.SpectralFlux(audio)
+    op.process()
+    assert op.process() > 0.0

--- a/tests/processing/test_zero_crossing_rate.py
+++ b/tests/processing/test_zero_crossing_rate.py
@@ -83,3 +83,13 @@ def test_zero_crossing_rate_empty() -> None:
     audio = DummyAudio(np.array([]))
     zcr = ZeroCrossingRate(audio)
     assert zcr.process() == 0.0
+
+
+def test_zero_crossing_rate_none_and_stereo() -> None:
+    audio_none = DummyAudio(None)
+    zcr = ZeroCrossingRate(audio_none)
+    assert zcr.process() == 0.0
+
+    stereo = np.array([[1.0, 1.0], [-1.0, -1.0], [1.0, 1.0], [-1.0, -1.0]])
+    zcr = ZeroCrossingRate(DummyAudio(stereo))
+    assert np.isclose(zcr.process(), 0.75)


### PR DESCRIPTION
## Summary
- add test suite for envelope, FFT bands, and spectral flux processing modules
- expand existing processing tests and ignore demo blocks
- configure coverage to track processing code only

## Testing
- `pytest -q`
- `pytest --cov -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0a0f72ebc83288b7e094ad1cb10ee