### PR TITLE
Require Link/MIDI deps and define transport interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,3 +160,27 @@ input_device.stop()
 ```
 
 Future input modules will support live audio, MIDI, OSC, and more.
+
+## ⏱️ Transport and Sync
+
+Oblique now includes an internal clock that tracks tempo, phase and musical
+position. Bridges let the clock sync via Ableton Link or an incoming MIDI clock
+so external gear and DAWs stay in phase.
+
+All transport sources expose ``state()`` returning a ``ClockState`` dataclass
+with tempo, bar, beat and phase information.
+
+Run the demo patch to view the transport in action. Use ``--link`` for Link
+sync or ``--midi PORT`` to follow a MIDI clock:
+
+```bash
+python projects/demo/transport_demo.py --link
+python projects/demo/transport_demo.py --midi "Elektron Digitakt"
+```
+
+On two laptops connected to the same network the tempo and phase will stay
+synchronized; changing the tempo on one propagates to the other.
+
+Ableton Link and MIDI support require the ``abletonlink`` and ``mido`` packages
+respectively, with a backend such as ``python-rtmidi`` for MIDI.
+

--- a/inputs/transport/__init__.py
+++ b/inputs/transport/__init__.py
@@ -1,0 +1,11 @@
+"""Transport and clock input modules."""
+
+from .clock import ClockState, Transport, AbletonLinkClock, MidiClock, TransportClock
+
+__all__ = [
+    "ClockState",
+    "Transport",
+    "TransportClock",
+    "AbletonLinkClock",
+    "MidiClock",
+]

--- a/inputs/transport/clock.py
+++ b/inputs/transport/clock.py
@@ -1,0 +1,155 @@
+"""Transport clocks with Link and MIDI synchronization."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Callable, Protocol
+
+import abletonlink  # type: ignore
+import mido  # type: ignore
+
+
+@dataclass
+class ClockState:
+    """Current timing information."""
+
+    bpm: float
+    beat: int
+    phase: float
+    bar: int
+    beats_per_bar: int
+
+
+class Transport(Protocol):
+    """Interface implemented by all transport clocks."""
+
+    def state(self) -> ClockState:
+        """Return the current :class:`ClockState`."""
+
+
+class TransportClock(Transport):
+    """Internal clock tracking tempo and musical position."""
+
+    def __init__(
+        self,
+        bpm: float = 120.0,
+        beats_per_bar: int = 4,
+        time_source: Callable[[], float] | None = None,
+    ) -> None:
+        self._bpm = bpm
+        self.beats_per_bar = beats_per_bar
+        self._time = time_source or time.monotonic
+        self._start_time = self._time()
+
+    @property
+    def bpm(self) -> float:
+        """Return current tempo in beats per minute."""
+
+        return self._bpm
+
+    def set_bpm(self, bpm: float) -> None:
+        """Update tempo while keeping phase continuous."""
+
+        state = self.state()
+        self._bpm = bpm
+        beats_elapsed = state.bar * self.beats_per_bar + state.beat + state.phase
+        self._start_time = self._time() - beats_elapsed * 60.0 / bpm
+
+    def state(self) -> ClockState:
+        """Return the current :class:`ClockState`."""
+
+        elapsed = self._time() - self._start_time
+        total_beats = elapsed * self._bpm / 60.0
+        bar = int(total_beats // self.beats_per_bar)
+        beat = int(total_beats % self.beats_per_bar)
+        phase = total_beats % 1.0
+        return ClockState(self._bpm, beat, phase, bar, self.beats_per_bar)
+
+
+class AbletonLinkClock(TransportClock):
+    """Clock synchronized via Ableton Link.
+
+    Tempo changes are propagated to the Link session so multiple peers stay in
+    phase.
+    """
+
+    def __init__(
+        self,
+        bpm: float = 120.0,
+        beats_per_bar: int = 4,
+        time_source: Callable[[], float] | None = None,
+    ) -> None:
+        super().__init__(bpm, beats_per_bar, time_source)
+        self._link = abletonlink.Link(bpm)  # pragma: no cover - requires external lib
+        self._session = self._link.capture_session_state()
+        self._link.enable(True)
+
+    def set_bpm(self, bpm: float) -> None:  # pragma: no cover - requires Link
+        super().set_bpm(bpm)
+        self._session.set_tempo(bpm, self._link.clock().micros())
+        self._link.commit_session_state(self._session)
+
+    def state(self) -> ClockState:
+        self._session = self._link.capture_session_state()  # pragma: no cover - requires Link
+        beat_time = self._session.beat()
+        tempo = self._session.tempo()
+        bar = int(beat_time // self.beats_per_bar)
+        beat = int(beat_time % self.beats_per_bar)
+        phase = beat_time % 1.0
+        self._bpm = tempo
+        return ClockState(tempo, beat, phase, bar, self.beats_per_bar)
+
+
+class MidiClock(TransportClock):
+    """Clock synchronized to incoming MIDI clock messages.
+
+    The class listens for MIDI realtime messages (start/stop/clock) and updates
+    the internal transport so external devices like Elektron machines stay in
+    phase.
+    """
+
+    TICKS_PER_BEAT = 24
+
+    def __init__(
+        self,
+        port: str | None = None,
+        bpm: float = 120.0,
+        beats_per_bar: int = 4,
+        time_source: Callable[[], float] | None = None,
+    ) -> None:
+        super().__init__(bpm, beats_per_bar, time_source)
+        self._tick_count = 0
+        self._running = False
+        self._last_tick: float | None = None
+        self._midi_in = None
+        if port is not None:  # pragma: no cover - requires MIDI
+            self._midi_in = mido.open_input(port, callback=self._handle)
+
+    def _handle(self, msg) -> None:  # pragma: no cover - callback
+        """Process a MIDI message."""
+
+        if msg.type == "start":
+            self._running = True
+            self._tick_count = 0
+            self._last_tick = None
+            self._start_time = self._time()
+        elif msg.type == "stop":
+            self._running = False
+        elif msg.type == "clock" and self._running:
+            now = self._time()
+            if self._last_tick is not None:
+                delta = now - self._last_tick
+                if delta > 0:
+                    bpm = 60.0 / (delta * self.TICKS_PER_BEAT)
+                    super().set_bpm(bpm)
+            self._tick_count += 1
+            beats_elapsed = self._tick_count / self.TICKS_PER_BEAT
+            self._start_time = now - beats_elapsed * 60.0 / self._bpm
+            self._last_tick = now
+
+    def close(self) -> None:  # pragma: no cover - requires MIDI
+        """Close the underlying MIDI port if open."""
+
+        if self._midi_in is not None:
+            self._midi_in.close()

--- a/projects/demo/transport_demo.py
+++ b/projects/demo/transport_demo.py
@@ -1,0 +1,37 @@
+"""Demonstrate the transport clock with Link or MIDI synchronization."""
+
+import argparse
+import time
+
+from inputs.transport import AbletonLinkClock, MidiClock, TransportClock
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Transport clock demo")
+    parser.add_argument("--link", action="store_true", help="Sync via Ableton Link")
+    parser.add_argument("--midi", metavar="PORT", help="Sync to a MIDI clock input")
+    args = parser.parse_args()
+
+    if args.midi:
+        clock = MidiClock(port=args.midi)
+    elif args.link:
+        clock = AbletonLinkClock()
+    else:
+        clock = TransportClock()
+
+    print("Press Ctrl+C to stop")
+    try:
+        while True:
+            state = clock.state()
+            print(
+                f"BPM {state.bpm:.1f} | Bar {state.bar} Beat {state.beat} "
+                f"Phase {state.phase:.2f}",
+                end="\r",
+            )
+            time.sleep(0.1)
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ typing_extensions
 Pillow
 pytest
 pytest-cov
+mido
+abletonlink

--- a/tests/test_transport_clock.py
+++ b/tests/test_transport_clock.py
@@ -1,0 +1,66 @@
+"""Tests for the transport clock."""
+
+import importlib
+from pathlib import Path
+import sys
+import types
+import mido
+
+from tests.utils.stubs import setup_stubs
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_basic_progression() -> None:
+    setup_stubs()
+    sys.modules["inputs"] = types.ModuleType("inputs")
+    sys.modules["inputs"].__path__ = [str(ROOT / "inputs")]
+    mod = importlib.import_module("inputs.transport.clock")
+    TransportClock = mod.TransportClock
+
+    t = 0.0
+
+    def time_source() -> float:
+        return t
+
+    clock = TransportClock(bpm=120.0, time_source=time_source)
+
+    state = clock.state()
+    assert state.bar == 0
+    assert state.beat == 0
+
+    t = 0.5  # one beat at 120 BPM
+    state = clock.state()
+    assert state.beat == 1
+
+    t = 2.0  # four beats -> next bar
+    state = clock.state()
+    assert state.bar == 1
+    assert state.beat == 0
+
+
+def test_midi_clock_progression() -> None:
+    setup_stubs()
+    sys.modules["inputs"] = types.ModuleType("inputs")
+    sys.modules["inputs"].__path__ = [str(ROOT / "inputs")]
+    mod = importlib.import_module("inputs.transport.clock")
+    MidiClock = mod.MidiClock
+
+    t = 0.0
+
+    def time_source() -> float:
+        return t
+
+    clock = MidiClock(port=None, time_source=time_source)
+    clock._handle(mido.Message("start"))
+
+    tick = 0.5 / clock.TICKS_PER_BEAT
+    for _ in range(clock.TICKS_PER_BEAT * 2):
+        t += tick
+        clock._handle(mido.Message("clock"))
+
+    state = clock.state()
+    assert state.bar == 0
+    assert state.beat == 2
+    assert abs(state.bpm - 120.0) < 1e-6

--- a/tests/utils/stubs.py
+++ b/tests/utils/stubs.py
@@ -135,6 +135,9 @@ def setup_stubs() -> None:
     if "sounddevice" not in sys.modules:
         sys.modules["sounddevice"] = types.SimpleNamespace(OutputStream=DummyOutputStream)
 
+    if "abletonlink" not in sys.modules:
+        sys.modules["abletonlink"] = types.SimpleNamespace(Link=lambda bpm: None)
+
     # Ensure core package and basic logger stubs
     if "core" not in sys.modules:
         core_pkg = types.ModuleType("core")


### PR DESCRIPTION
## Summary
- remove optional dependency checks from transport clocks and import abletonlink/mido directly
- introduce Transport protocol and export ClockState/Transport via transport module
- document transport interface and required Link/MIDI dependencies

## Testing
- ⚠️ `pip install abletonlink` (no matching distribution found)
- ✅ `pip install mido`
- ✅ `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0a1774ce08328b2fb63b0af8bdbd9