### PR TITLE
Add REPL and shader hot reload flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ load the patch.
 
 # Or run manually
 python main.py --audio "path/to/audio.wav" --width 800 --height 600 --audio "path_to_audio"
+
+# Enable live shader editing
+python main.py --hot-reload-shaders
+
+# Launch the interactive REPL with a patch
+python repl.py projects.demo.shader_test shader_test --hot-reload-shaders
 ```
 
 

--- a/core/oblique_engine.py
+++ b/core/oblique_engine.py
@@ -47,7 +47,7 @@ class ObliqueEngine:
         height: int = 600,
         title: str = "Oblique MVP",
         target_fps: int = 60,
-        debug: bool = False,
+        hot_reload_shaders: bool = False,
         monitor: Optional[int] = None,
     ):
         """
@@ -59,7 +59,7 @@ class ObliqueEngine:
             height: Window height in pixels
             title: Window title
             target_fps: Target frame rate for rendering
-            debug: Enable debug mode with performance monitoring
+            hot_reload_shaders: Reload shaders from disk every frame
             monitor: Monitor index to open window on (None for default)
         """
         self.patch = patch
@@ -68,12 +68,12 @@ class ObliqueEngine:
         self.title = title
         self.target_fps = target_fps
         self.frame_duration = 1.0 / target_fps
-        self.debug = debug
+        self.hot_reload_shaders = hot_reload_shaders
         self.monitor = monitor
-        # Set global debug mode for shader reloading
-        from core.renderer import set_debug_mode
+        # Set global shader hot reload mode
+        from core.renderer import set_hot_reload_shaders
 
-        set_debug_mode(debug)
+        set_hot_reload_shaders(hot_reload_shaders)
 
         # Performance monitoring
         self.performance_monitor = PerformanceMonitor()
@@ -117,8 +117,8 @@ class ObliqueEngine:
 
             info(f"Starting Oblique engine with patch {self.patch}")
 
-            if self.debug:
-                info("Debug mode enabled - Performance monitoring active")
+            if self.hot_reload_shaders:
+                info("Hot shader reload enabled")
 
             if self.audio_output is not None:
                 self.audio_output.start()
@@ -404,12 +404,8 @@ class ObliqueEngine:
 
 
     def get_performance_stats(self) -> Optional[Dict[str, float]]:
-        """
-        Get current performance statistics if debug mode is enabled.
+        """Get current performance statistics."""
 
-        Returns:
-            Performance statistics dictionary or None if debug mode is disabled
-        """
         if self.performance_monitor:
             return self.performance_monitor.get_stats()
         return None

--- a/main.py
+++ b/main.py
@@ -51,9 +51,9 @@ def main():
     )
     parser.add_argument("--fps", type=int, default=60, help="Target frame rate")
     parser.add_argument(
-        "--debug",
+        "--hot-reload-shaders",
         action="store_true",
-        help="Enable debug mode with performance monitoring",
+        help="Reload shaders from disk every frame",
         default=False,
     )
     parser.add_argument(
@@ -133,7 +133,7 @@ def main():
         height=args.height,
         title="Oblique MVP",
         target_fps=args.fps,
-        debug=args.debug,
+        hot_reload_shaders=args.hot_reload_shaders,
         monitor=args.monitor,
     )
 

--- a/projects/demo/shader_test.py
+++ b/projects/demo/shader_test.py
@@ -99,7 +99,7 @@ if __name__ == "__main__":
         height=600,
         title="Shader Test",
         target_fps=60,
-        debug=False,
+        hot_reload_shaders=False,
         monitor=None,
     )
 

--- a/repl.py
+++ b/repl.py
@@ -1,0 +1,78 @@
+"""Interactive REPL runner for Oblique patches.
+
+This utility starts an :class:`~core.oblique_engine.ObliqueEngine` in a background
+thread and drops the user into a Python REPL. The active engine instance and a
+``reload_patch`` helper are exposed in the console's local scope so patches can
+be edited and reloaded on the fly. Shader hot reloading can be toggled via the
+``--hot-reload-shaders`` flag.
+"""
+
+import argparse
+import importlib
+import threading
+import code
+
+from core import ObliqueEngine
+from core.logger import configure_logging, info, error
+
+
+def _load_patch(module_name: str, func_name: str, width: int, height: int):
+    """Import a patch factory and instantiate an :class:`ObliquePatch`."""
+
+    module = importlib.import_module(module_name)
+    factory = getattr(module, func_name)
+    return factory(width, height)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Oblique patch REPL")
+    parser.add_argument("module", help="Patch module path, e.g. projects.demo.shader_test")
+    parser.add_argument("function", help="Patch factory function name")
+    parser.add_argument("--width", type=int, default=800)
+    parser.add_argument("--height", type=int, default=600)
+    parser.add_argument("--fps", type=int, default=60, help="Target frame rate")
+    parser.add_argument("--hot-reload-shaders", action="store_true", default=False)
+    parser.add_argument("--log-level", type=str, default="INFO",
+                        choices=["FATAL", "ERROR", "WARNING", "INFO", "DEBUG", "TRACE"],
+                        help="Logging level")
+    parser.add_argument("--log-file", type=str, default=None, help="Optional log file path")
+
+    args = parser.parse_args()
+
+    configure_logging(level=args.log_level, log_to_file=args.log_file is not None, log_file_path=args.log_file)
+
+    try:
+        patch = _load_patch(args.module, args.function, args.width, args.height)
+    except Exception as exc:  # pragma: no cover - defensive logging
+        error(f"Failed to load patch: {exc}")
+        raise
+
+    engine = ObliqueEngine(
+        patch=patch,
+        width=args.width,
+        height=args.height,
+        target_fps=args.fps,
+        hot_reload_shaders=args.hot_reload_shaders,
+    )
+
+    engine_thread = threading.Thread(target=engine.run, daemon=True)
+    engine_thread.start()
+
+    def reload_patch() -> None:
+        module = importlib.import_module(args.module)
+        importlib.reload(module)
+        engine.patch = _load_patch(args.module, args.function, args.width, args.height)
+        info("Patch reloaded")
+
+    banner = (
+        "Oblique REPL.\n"
+        "Edit your patch and call reload_patch() to apply changes.\n"
+        "The running engine is available as 'engine'."
+    )
+    console_locals = {"engine": engine, "reload_patch": reload_patch}
+    code.InteractiveConsole(console_locals).interact(banner=banner)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/start.sh
+++ b/start.sh
@@ -15,11 +15,11 @@ if [ "$1" = "--list-audio-devices" ]; then
   exit 0
 fi
 
-# Parse debug parameter
-DEBUG_FLAG=""
-if [ "$1" = "--debug" ]; then
-  DEBUG_FLAG="--debug"
-  shift  # Remove the debug parameter from arguments
+# Parse hot-reload-shaders parameter
+HOT_RELOAD_FLAG=""
+if [ "$1" = "--hot-reload-shaders" ]; then
+  HOT_RELOAD_FLAG="--hot-reload-shaders"
+  shift  # Remove the parameter from arguments
 fi
 
 # Parse syntakt parameter
@@ -28,9 +28,9 @@ AUDIO_DEVICE="0"
 if [ "$1" = "--syntakt" ]; then
   SYNTAKT_FLAG="--syntakt"
   shift  # Remove the syntakt parameter from arguments
-  
+
   echo "[INFO] Looking for Syntakt audio device..."
-  
+
   # Create a temporary script to find syntakt device
   cat > /tmp/find_syntakt.py << 'EOF'
 import sys
@@ -39,21 +39,21 @@ sys.path.insert(0, os.getcwd())
 
 try:
     import sounddevice as sd
-    
+
     # Get all devices
     devices = sd.query_devices()
     syntakt_device = None
-    
+
     for i, device in enumerate(devices):
         device_name = device.get('name', '').lower()
         if 'syntakt' in device_name:
             syntakt_device = i
             print(f"FOUND:{i}:{device.get('name', 'Unknown')}")
             break
-    
+
     if syntakt_device is None:
         print("NOT_FOUND")
-        
+
 except Exception as e:
     print(f"ERROR:{str(e)}")
 EOF
@@ -61,7 +61,7 @@ EOF
   # Run the temporary script
   RESULT=$(python3 /tmp/find_syntakt.py 2>/dev/null)
   rm -f /tmp/find_syntakt.py
-  
+
   if [[ "$RESULT" == FOUND:* ]]; then
     # Parse the result: FOUND:device_id:device_name
     IFS=':' read -r _ device_id device_name <<< "$RESULT"
@@ -80,11 +80,12 @@ MONITOR=${MONITOR:-1}
 
 echo "[DEBUG] Starting Oblique MVP with default settings..."
 echo "[DEBUG] Using monitor: $MONITOR"
-if [ -n "$DEBUG_FLAG" ]; then
-  echo "[DEBUG] Debug mode enabled"
+if [ -n "$HOT_RELOAD_FLAG" ]; then
+  echo "[DEBUG] Shader hot-reload enabled"
 fi
 if [ -n "$SYNTAKT_FLAG" ]; then
   echo "[DEBUG] Syntakt mode enabled, using audio device: $AUDIO_DEVICE"
 fi
-# python3 main.py --audio-file "projects/demo/audio/Just takes one try mix even shorter [master]19.06.2025.wav" --width 800 --height 800 $DEBUG_FLAG --monitor "$MONITOR" "$@" 
-python3 main.py --width 800 --height 800 $DEBUG_FLAG --monitor "$MONITOR" "$@" --audio-device "$AUDIO_DEVICE"
+# python3 main.py --audio-file "projects/demo/audio/Just takes one try mix even shorter [master]19.06.2025.wav" --width 800 --height 800 $HOT_RELOAD_FLAG --monitor "$MONITOR" "$@"
+python3 main.py --width 800 --height 800 $HOT_RELOAD_FLAG --monitor "$MONITOR" "$@" --audio-device "$AUDIO_DEVICE"
+

--- a/tests/core/test_oblique_engine.py
+++ b/tests/core/test_oblique_engine.py
@@ -17,7 +17,7 @@ def _create_engine():
     patch_mod = load_module("core.oblique_patch", ROOT / "core" / "oblique_patch.py")
     engine_mod = load_module("core.oblique_engine", ROOT / "core" / "oblique_engine.py")
     patch = patch_mod.ObliquePatch(lambda t: None)
-    return engine_mod.ObliqueEngine(patch, debug=True)
+    return engine_mod.ObliqueEngine(patch, hot_reload_shaders=True)
 
 
 def test_get_performance_stats():

--- a/tests/core/test_renderer.py
+++ b/tests/core/test_renderer.py
@@ -10,13 +10,13 @@ from tests.utils.stubs import setup_stubs, load_module
 ROOT = Path(__file__).resolve().parents[2]
 
 
-def test_set_debug_mode_and_ctx():
+def test_set_hot_reload_and_ctx():
     setup_stubs()
     renderer = load_module("core.renderer", ROOT / "core" / "renderer.py")
 
     ctx = object()
-    renderer.set_debug_mode(True)
-    assert renderer._debug_mode is True
+    renderer.set_hot_reload_shaders(True)
+    assert renderer._hot_reload_shaders_enabled is True
     renderer.set_ctx(ctx)  # type: ignore[arg-type]
     assert renderer._ctx is ctx
 
@@ -34,7 +34,9 @@ def test_cleanup_shader_cache():
         def release(self):
             released[self.key] = True
 
-    renderer._shader_cache["test"] = (Dummy("program"), Dummy("vao"), Dummy("vbo"))
+    renderer._shader_cache["test"] = renderer.ShaderCacheEntry(
+        Dummy("program"), Dummy("vao"), Dummy("vbo"), 0.0
+    )
     renderer.cleanup_shader_cache()
     assert renderer._shader_cache == {}
     assert all(released.values())
@@ -71,3 +73,32 @@ def test_render_fullscreen_quad_caches():
     assert shader_path in renderer._shader_cache
     renderer.render_fullscreen_quad(ctx, shader_path, {})
     assert len(renderer._shader_cache) == 1
+
+
+def test_hot_reload_only_on_change(tmp_path):
+    setup_stubs()
+    renderer = load_module("core.renderer", ROOT / "core" / "renderer.py")
+    import moderngl
+    import time
+
+    ctx = moderngl.create_context()
+    shader_src = (ROOT / "shaders" / "passthrough.frag").read_text()
+    shader_file = tmp_path / "temp.frag"
+    shader_file.write_text(shader_src)
+
+    renderer.set_hot_reload_shaders(True)
+    renderer._shader_cache.clear()
+
+    renderer.render_fullscreen_quad(ctx, str(shader_file), {})
+    first_program = renderer._shader_cache[str(shader_file)].program
+
+    renderer.render_fullscreen_quad(ctx, str(shader_file), {})
+    second_program = renderer._shader_cache[str(shader_file)].program
+    assert first_program is second_program
+
+    time.sleep(1)
+    shader_file.write_text(shader_src + "\n// mod")
+
+    renderer.render_fullscreen_quad(ctx, str(shader_file), {})
+    third_program = renderer._shader_cache[str(shader_file)].program
+    assert third_program is not first_program


### PR DESCRIPTION
## Summary
- add `--hot-reload-shaders` flag and remove old debug flag
- expose shader hot reload through `set_hot_reload_shaders`
- introduce `repl.py` for interactive patch editing
- cache shader modification times so hot-reload recompiles only changed shaders
- strongly type shader cache entries and clarify hot reload flag

## Testing
- `source venv/bin/activate && pytest` *(fails: No such file or directory)*
- `pytest`
- `./start.sh` *(fails: venv not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a23ee15a108328b6f8c85f3738367f