### PR TITLE
Add circular pattern AV module

### DIFF
--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -4,6 +4,7 @@ from .effects.feedback import FeedbackModule, FeedbackParams
 from .audio_reactive.grid_swap_module import GridSwapModule, GridSwapModuleParams
 from .audio_reactive.ikeda_tiny_barcode import IkedaTinyBarcodeModule, IkedaTinyBarcodeParams
 from .effects.level_module import LevelModule, LevelParams
+from .effects.circular_pattern import CircularPatternModule, CircularPatternParams
 from .audio_reactive.pauric_squares_module import PauricSquaresModule, PauricSquaresParams
 from .audio_reactive.ryoji_lines import RyojiLines, RyojiLinesParams
 from .audio_reactive.spectral_visualizer import SpectralVisualizerModule, SpectralVisualizerParams

--- a/modules/effects/circular_pattern.py
+++ b/modules/effects/circular_pattern.py
@@ -1,0 +1,59 @@
+from dataclasses import dataclass
+
+from modules.core.base_av_module import (
+    BaseAVModule,
+    BaseAVParams,
+    ParamFloat,
+    ParamInt,
+    Uniforms,
+)
+
+
+@dataclass
+class CircularPatternParams(BaseAVParams):
+    """Parameters for the CircularPattern module."""
+
+    ring_count: ParamFloat = 80.0  # Number of concentric rings
+    segment_count: ParamInt = 64  # Angular segmentation
+    line_width: ParamFloat = 0.02  # Thickness of the ring lines
+    noise_amplitude: ParamFloat = 0.3  # Amount of radial distortion
+    speed: ParamFloat = 0.25  # Animation speed for noise
+
+
+class CircularPatternUniforms(Uniforms, total=True):
+    u_time: float
+    u_ring_count: float
+    u_segment_count: int
+    u_line_width: float
+    u_noise_amplitude: float
+    u_speed: float
+
+
+class CircularPatternModule(BaseAVModule[CircularPatternParams, CircularPatternUniforms]):
+    """Generate concentric circular lines with angular noise displacement."""
+
+    metadata = {
+        "name": "CircularPatternModule",
+        "description": (
+            "Generates concentric circular lines distorted per-segment with"
+            " simplex noise."
+        ),
+        "parameters": CircularPatternParams.__annotations__,
+    }
+    frag_shader_path: str = "modules/effects/shaders/circular-pattern.frag"
+
+    def __init__(self, params: CircularPatternParams):
+        super().__init__(params)
+
+    def prepare_uniforms(self, t: float) -> CircularPatternUniforms:
+        uniforms: CircularPatternUniforms = {
+            "u_time": t,
+            "u_resolution": self._resolve_resolution(),
+            "u_ring_count": self._resolve_param(self.params.ring_count),
+            "u_segment_count": self._resolve_param(self.params.segment_count),
+            "u_line_width": self._resolve_param(self.params.line_width),
+            "u_noise_amplitude": self._resolve_param(self.params.noise_amplitude),
+            "u_speed": self._resolve_param(self.params.speed),
+        }
+
+        return uniforms

--- a/modules/effects/shaders/circular-pattern.frag
+++ b/modules/effects/shaders/circular-pattern.frag
@@ -1,0 +1,51 @@
+#version 330
+/*
+Circular Pattern shader for Oblique
+Author: Oblique MVP
+Description: Generates concentric circular lines with per-segment noise distortion.
+Inputs:
+  uniform float u_time;            // Current time
+  uniform vec2 u_resolution;       // Viewport resolution
+  uniform float u_ring_count;      // Number of concentric rings
+  uniform int u_segment_count;     // Number of angular segments
+  uniform float u_line_width;      // Thickness of ring lines
+  uniform float u_noise_amplitude; // Amount of radial noise
+  uniform float u_speed;           // Animation speed
+*/
+
+#ifdef GL_ES
+precision mediump float;
+#endif
+
+#include <lygia/space/cart2polar.glsl>
+#include <lygia/generative/snoise.glsl>
+
+uniform float u_time;
+uniform vec2 u_resolution;
+uniform float u_ring_count;
+uniform int u_segment_count;
+uniform float u_line_width;
+uniform float u_noise_amplitude;
+uniform float u_speed;
+
+in vec2 v_uv;
+out vec4 fragColor;
+
+void main() {
+    vec2 uv = v_uv;
+    vec2 centered = (uv - 0.5) * 2.0;
+    vec2 polar = cart2polar(centered);
+    float angle = polar.x;
+    float radius = polar.y;
+
+    float segment = floor((angle + 3.14159265) / (2.0 * 3.14159265)
+                          * float(u_segment_count));
+    float base = radius * u_ring_count;
+    float n = snoise(vec2(segment, floor(base)) + u_time * u_speed);
+    float displaced = base + n * u_noise_amplitude;
+    float ring = fract(displaced);
+    float line = step(u_line_width, ring);
+
+    float color = 1.0 - line;
+    fragColor = vec4(vec3(color), 1.0);
+}

--- a/tests/modules/test_circular_pattern_module.py
+++ b/tests/modules/test_circular_pattern_module.py
@@ -1,0 +1,13 @@
+from modules.effects.circular_pattern import (
+    CircularPatternModule,
+    CircularPatternParams,
+)
+
+
+def test_circular_pattern_uniforms() -> None:
+    params = CircularPatternParams(width=640, height=480)
+    module = CircularPatternModule(params)
+    uniforms = module.prepare_uniforms(1.0)
+    assert uniforms["u_resolution"] == (640, 480)
+    assert "u_ring_count" in uniforms
+    assert "u_segment_count" in uniforms


### PR DESCRIPTION
## Summary
- add CircularPatternModule to generate concentric lines with per-segment noise
- leverage lygia cart2polar and snoise includes for shader-based distortion
- cover module with basic uniform test

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a23df811388328aa54c8e43596b340