### PR TITLE
Preserve log outputs with unique filenames

### DIFF
--- a/core/logger.py
+++ b/core/logger.py
@@ -102,16 +102,45 @@ class ObliqueLogger:
                 timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
                 log_file_path = logs_dir / f"oblique_{timestamp}.log"
 
-            self._log_file = Path(log_file_path)
-            self._log_file.parent.mkdir(parents=True, exist_ok=True)
-
-            self._file_handler = logging.FileHandler(self._log_file)
+            requested_path = Path(log_file_path)
+            self._log_file = self._ensure_unique_log_path(requested_path)
+            try:
+                self._log_file.parent.mkdir(parents=True, exist_ok=True)
+                self._file_handler = logging.FileHandler(self._log_file)
+            except OSError as exc:
+                raise RuntimeError(
+                    f"Unable to create log file at '{self._log_file}': {exc}"
+                ) from exc
             self._file_handler.setLevel(logging.DEBUG)  # File gets all logs
             self._file_handler.setFormatter(formatter)
             self._logger.addHandler(self._file_handler)
 
             # Log the configuration
-            self.info(f"Logging to file: {self._log_file}")
+            if self._log_file == requested_path:
+                self.info(f"Logging to file: {self._log_file}")
+            else:
+                self.info(
+                    "Logging to file: {path} (requested {requested})",
+                    path=self._log_file,
+                    requested=requested_path
+                )
+
+    def _ensure_unique_log_path(self, log_file_path: Path) -> Path:
+        """Return a unique log path when the target file already exists."""
+        if not log_file_path.exists():
+            return log_file_path
+
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        for suffix_index in range(1, 1000):
+            candidate = log_file_path.with_name(
+                f"{log_file_path.stem}_{timestamp}_{suffix_index}{log_file_path.suffix}"
+            )
+            if not candidate.exists():
+                return candidate
+
+        raise RuntimeError(
+            "Unable to create a unique log file name after 1000 attempts."
+        )
 
     def get_logger(self) -> logging.Logger:
         """Get the configured logger instance."""


### PR DESCRIPTION
### Motivation
- Prevent log outputs from being overwritten so logs from different runs or code versions can be preserved and compared.
- Surface when a requested log path is adjusted and fail fast when a log file cannot be created.

### Description
- Add `ObliqueLogger._ensure_unique_log_path` to return a non‑existing path when the requested file already exists by appending a timestamp and numeric suffix.
- Use the unique path when creating the file handler and raise a `RuntimeError` with context if directory/file creation fails.
- When the final log path differs from the requested path, include both paths in the `info` message so callers know which file was actually created.

### Testing
- Attempted to run `source venv/bin/activate && pytest`, but the command failed because `venv/bin/activate` was not found, so automated tests were not executed.
- The change was committed locally; please run `pytest` in your environment (or activate the project virtualenv) to validate on CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d141232f883288bc079ec62d85a22)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds safeguards to prevent log file overwrites and improves observability around log file creation.
> 
> - Introduces `ObliqueLogger._ensure_unique_log_path` to generate a non-existing path when the requested log file already exists (timestamp + numeric suffix)
> - Wraps file handler creation in `try/except` to raise a `RuntimeError` with path/context on failure; ensures parent dirs exist
> - Logs both requested and final paths when they differ to make adjustments explicit
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 40cbeca5833da7149e476be5e6132ec8f1f17dcb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->